### PR TITLE
feat: check overflow

### DIFF
--- a/src/types.rs
+++ b/src/types.rs
@@ -92,6 +92,7 @@ pub enum SelectionError {
     NonPositiveTarget,
     NonPositiveFeeRate,
     AbnormallyHighFeeRate,
+    AbnormallyHighAmount,
 }
 
 /// Measures the efficiency of input selection in satoshis, helping evaluate algorithms based on current and long-term fee rates

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -43,6 +43,11 @@ pub fn calculate_accumulated_weight(
     }
     accumulated_weight
 }
+/// sugar to return a SelectionError when overflowing
+pub fn sum(a: u64, b: u64) -> Result<u64> {
+    a.checked_add(b)
+        .ok_or_else(|| SelectionError::AbnormallyHighAmount)
+}
 
 impl fmt::Display for SelectionError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -52,6 +57,7 @@ impl fmt::Display for SelectionError {
             SelectionError::AbnormallyHighFeeRate => write!(f, "Abnormally high fee rate"),
             SelectionError::InsufficientFunds => write!(f, "The Inputs funds are insufficient"),
             SelectionError::NoSolutionFound => write!(f, "No solution could be derived"),
+            SelectionError::AbnormallyHighAmount => write!(f, "Abnormally high amount"),
         }
     }
 }


### PR DESCRIPTION
That's a suggestion for how to handle operations that would overflow u64. If an overflow occurs, algorithms will returns an error.

To avoid having a lot of `.checked_add(value).ok_or_else(||SelectionError::AbnormalHighValure)?` repeated over the code, which can be a bit hard to read, a simple function [sum](https://github.com/Cyrix126/rust-coinselect/blob/05ce78323dd50d43587fd2112413a7d3ad3f88f7/src/utils.rs#L47) reside in src/utils.rs

Another way would be to check at [select_coin](https://github.com/citadel-tech/rust-coinselect/blob/3b128e4b73852768c65c88105a4deba045af8d60/src/selectcoin.rs#L19) if the values given in inputs and options are abnormal. But then the overflows would still occur if the different algorithms are used directly.

